### PR TITLE
feat: implement K8sRuntime.CreateWorkspace with COOWorkspace CR creation and readiness polling

### DIFF
--- a/internal/runtime/k8s.go
+++ b/internal/runtime/k8s.go
@@ -1,23 +1,47 @@
 package runtime
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
-	cooAPIGroup    = "coo.itsacoo.com"
-	k8sProbeTimeout = 5 * time.Second
+	cooAPIGroup        = "coo.itsacoo.com"
+	cooAPIVersion      = "v1alpha1"
+	k8sProbeTimeout    = 5 * time.Second
+	createReadyTimeout = 120 * time.Second
+	createPollInterval = 2 * time.Second
+	defaultNamespace   = "coo-system"
+	defaultWorkerImage = "ghcr.io/bobbydeveaux/code-orchestrator-operator/coo-worker-claude:latest"
+	workspaceContainer = "workspace"
 )
+
+var cooWorkspaceGVR = schema.GroupVersionResource{
+	Group:    cooAPIGroup,
+	Version:  cooAPIVersion,
+	Resource: "cooworkspaces",
+}
 
 // K8sRuntime implements Runtime using the itsacoo operator and COOWorkspace CRs.
 type K8sRuntime struct {
 	cfg             Config
 	discoveryClient discovery.DiscoveryInterface
+	dynamicClient   dynamic.Interface
+	restConfig      *rest.Config
+	namespace       string
 }
 
 // newK8sRuntime creates a K8sRuntime after verifying the k8s API is reachable
@@ -32,10 +56,27 @@ func newK8sRuntime(ctx context.Context, cfg Config) (*K8sRuntime, error) {
 		return nil, fmt.Errorf("COO operator not detected: %w", err)
 	}
 
-	return &K8sRuntime{cfg: cfg, discoveryClient: dc}, nil
+	dynClient, restCfg, err := buildRuntimeClients(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build k8s runtime clients: %w", err)
+	}
+
+	ns := cfg.Namespace
+	if ns == "" {
+		ns = defaultNamespace
+	}
+
+	return &K8sRuntime{
+		cfg:             cfg,
+		discoveryClient: dc,
+		dynamicClient:   dynClient,
+		restConfig:      restCfg,
+		namespace:       ns,
+	}, nil
 }
 
-// buildDiscoveryClient constructs a discovery client from the provided config.
+// buildDiscoveryClient constructs a short-timeout discovery client used for
+// probing whether the k8s API and COO CRDs are present.
 func buildDiscoveryClient(cfg Config) (discovery.DiscoveryInterface, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if cfg.Kubeconfig != "" {
@@ -61,6 +102,35 @@ func buildDiscoveryClient(cfg Config) (discovery.DiscoveryInterface, error) {
 	return discovery.NewDiscoveryClientForConfig(restCfg)
 }
 
+// buildRuntimeClients constructs a dynamic client and REST config for runtime
+// operations (no short probe timeout).
+func buildRuntimeClients(cfg Config) (dynamic.Interface, *rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if cfg.Kubeconfig != "" {
+		loadingRules.ExplicitPath = cfg.Kubeconfig
+	}
+
+	overrides := &clientcmd.ConfigOverrides{}
+	if cfg.KubeContext != "" {
+		overrides.CurrentContext = cfg.KubeContext
+	}
+
+	restCfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules,
+		overrides,
+	).ClientConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("load kubeconfig: %w", err)
+	}
+
+	dynClient, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create dynamic client: %w", err)
+	}
+
+	return dynClient, restCfg, nil
+}
+
 // probeCOOCRD checks that the k8s API server is reachable and that the
 // coo.itsacoo.com API group (COO operator CRDs) is registered.
 func probeCOOCRD(dc discovery.DiscoveryInterface) error {
@@ -81,9 +151,231 @@ func probeCOOCRD(dc discovery.DiscoveryInterface) error {
 // Type implements Runtime.
 func (r *K8sRuntime) Type() RuntimeType { return RuntimeK8s }
 
-// CreateWorkspace implements Runtime.
+// CreateWorkspace implements Runtime. It lists existing non-terminated
+// workspaces, optionally prompts to resume one, then creates a new
+// COOWorkspace CR and polls until it is Ready before exec-ing in.
 func (r *K8sRuntime) CreateWorkspace(ctx context.Context, opts CreateOptions) error {
-	return fmt.Errorf("k8s CreateWorkspace: not yet implemented")
+	if opts.Repo == "" && opts.Concept == "" {
+		return fmt.Errorf("one of --repo or --concept is required")
+	}
+
+	// 1. List non-terminated workspaces and offer to resume.
+	active, err := r.listActiveWorkspaces(ctx)
+	if err != nil {
+		return fmt.Errorf("list existing workspaces: %w", err)
+	}
+
+	if len(active) > 0 {
+		resumed, err := r.promptResume(ctx, active)
+		if err != nil {
+			return err
+		}
+		if resumed {
+			return nil
+		}
+	}
+
+	// 2. Generate workspace name.
+	name := fmt.Sprintf("ws-%d", time.Now().Unix())
+
+	// 3. Determine mode and resolve image.
+	mode := "freestyle"
+	if opts.Concept != "" {
+		mode = "handoff"
+	}
+	image := opts.Image
+	if image == "" {
+		image = defaultWorkerImage
+	}
+
+	// 4. Build and create the COOWorkspace CR.
+	wsObj := buildCOOWorkspace(name, r.namespace, mode, opts, image)
+	fmt.Printf("Creating workspace %s...\n", name)
+
+	_, err = r.dynamicClient.Resource(cooWorkspaceGVR).Namespace(r.namespace).Create(
+		ctx, wsObj, metav1.CreateOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("create COOWorkspace %s: %w", name, err)
+	}
+
+	// 5. Poll until Ready.
+	podName, err := r.waitForReady(ctx, name)
+	if err != nil {
+		return fmt.Errorf("workspace %s did not become ready: %w", name, err)
+	}
+
+	// 6. Exec into the workspace pod.
+	fmt.Printf("Exec-ing into workspace pod %s...\n", podName)
+	if err := r.execIntoPod(podName); err != nil {
+		return fmt.Errorf("exec into workspace: %w", err)
+	}
+
+	fmt.Printf("\nResume this session: coo workspace resume %s\n", name)
+	return nil
+}
+
+// listActiveWorkspaces returns COOWorkspaces whose status.phase is not
+// "Terminated" (and not empty, which means not yet initialised).
+func (r *K8sRuntime) listActiveWorkspaces(ctx context.Context) ([]unstructured.Unstructured, error) {
+	list, err := r.dynamicClient.Resource(cooWorkspaceGVR).Namespace(r.namespace).List(
+		ctx, metav1.ListOptions{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var active []unstructured.Unstructured
+	for _, item := range list.Items {
+		phase, _, _ := unstructured.NestedString(item.Object, "status", "phase")
+		if phase != "" && phase != "Terminated" {
+			active = append(active, item)
+		}
+	}
+	return active, nil
+}
+
+// promptResume prints the active workspace list and asks whether to resume one.
+// Returns (true, nil) if the user chose to resume, (false, nil) to create new.
+func (r *K8sRuntime) promptResume(ctx context.Context, active []unstructured.Unstructured) (bool, error) {
+	fmt.Println("Existing workspaces:")
+	for i, ws := range active {
+		phase, _, _ := unstructured.NestedString(ws.Object, "status", "phase")
+		repo, _, _ := unstructured.NestedString(ws.Object, "spec", "repo")
+		fmt.Printf("  [%d] %s  phase=%s  repo=%s\n", i+1, ws.GetName(), phase, repo)
+	}
+	fmt.Print("Press Enter to create a new workspace, or enter a number to resume: ")
+
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Scan()
+	input := strings.TrimSpace(scanner.Text())
+
+	if input == "" {
+		return false, nil
+	}
+
+	var idx int
+	if _, err := fmt.Sscanf(input, "%d", &idx); err != nil || idx < 1 || idx > len(active) {
+		return false, fmt.Errorf("invalid selection %q", input)
+	}
+
+	return true, r.ResumeWorkspace(ctx, active[idx-1].GetName())
+}
+
+// waitForReady polls the COOWorkspace until status.phase == "Ready", returning
+// the pod name. It times out after createReadyTimeout.
+func (r *K8sRuntime) waitForReady(ctx context.Context, name string) (string, error) {
+	return r.waitForReadyWithInterval(ctx, name, createPollInterval)
+}
+
+// waitForReadyWithInterval is the testable core of waitForReady, accepting a
+// configurable poll interval.
+func (r *K8sRuntime) waitForReadyWithInterval(ctx context.Context, name string, interval time.Duration) (string, error) {
+	deadline := time.Now().Add(createReadyTimeout)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	fmt.Print("Waiting for workspace to be ready")
+
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println()
+			return "", ctx.Err()
+		case <-ticker.C:
+			if time.Now().After(deadline) {
+				fmt.Println()
+				return "", fmt.Errorf("timed out after %s waiting for workspace to be ready", createReadyTimeout)
+			}
+
+			ws, err := r.dynamicClient.Resource(cooWorkspaceGVR).Namespace(r.namespace).Get(
+				ctx, name, metav1.GetOptions{},
+			)
+			if err != nil {
+				fmt.Print(".")
+				continue
+			}
+
+			phase, _, _ := unstructured.NestedString(ws.Object, "status", "phase")
+			switch phase {
+			case "Ready":
+				fmt.Println(" Ready!")
+				podName, _, _ := unstructured.NestedString(ws.Object, "status", "podName")
+				return podName, nil
+			case "Failed", "Error":
+				fmt.Println()
+				msg, _, _ := unstructured.NestedString(ws.Object, "status", "message")
+				if msg != "" {
+					return "", fmt.Errorf("workspace entered %s phase: %s", phase, msg)
+				}
+				return "", fmt.Errorf("workspace entered %s phase", phase)
+			default:
+				fmt.Print(".")
+			}
+		}
+	}
+}
+
+// execIntoPod runs kubectl exec -it into the workspace container.
+func (r *K8sRuntime) execIntoPod(podName string) error {
+	args := []string{
+		"exec", "-it", podName,
+		"-n", r.namespace,
+		"-c", workspaceContainer,
+		"--",
+		"bash", "-c", "cd /workspace && claude --dangerously-skip-permissions",
+	}
+
+	if r.cfg.Kubeconfig != "" {
+		args = append([]string{"--kubeconfig", r.cfg.Kubeconfig}, args...)
+	}
+	if r.cfg.KubeContext != "" {
+		args = append([]string{"--context", r.cfg.KubeContext}, args...)
+	}
+
+	cmd := exec.Command("kubectl", args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// buildCOOWorkspace constructs the unstructured COOWorkspace object for creation.
+func buildCOOWorkspace(name, namespace, mode string, opts CreateOptions, image string) *unstructured.Unstructured {
+	model := opts.Model
+	if model == "" {
+		model = "claude-sonnet-4-5"
+	}
+	ttl := opts.TTL
+	if ttl == "" {
+		ttl = "4h"
+	}
+
+	spec := map[string]interface{}{
+		"mode":            mode,
+		"model":           model,
+		"ttl":             ttl,
+		"image":           image,
+		"imagePullPolicy": "IfNotPresent",
+	}
+	if opts.Repo != "" {
+		spec["repo"] = opts.Repo
+	}
+	if opts.Concept != "" {
+		spec["conceptRef"] = opts.Concept
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": cooAPIGroup + "/" + cooAPIVersion,
+			"kind":       "COOWorkspace",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": spec,
+		},
+	}
 }
 
 // ListWorkspaces implements Runtime.

--- a/internal/runtime/k8s_test.go
+++ b/internal/runtime/k8s_test.go
@@ -1,0 +1,308 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+// newTestK8sRuntime builds a K8sRuntime pointed at the given test server.
+func newTestK8sRuntime(t *testing.T, serverURL string) *K8sRuntime {
+	t.Helper()
+	restCfg := &rest.Config{Host: serverURL}
+	dynClient, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		t.Fatalf("create dynamic client: %v", err)
+	}
+	return &K8sRuntime{
+		dynamicClient: dynClient,
+		restConfig:    restCfg,
+		namespace:     defaultNamespace,
+	}
+}
+
+// mustMarshal serialises v to JSON, fatally failing the test on error.
+func mustMarshal(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// unstructuredWorkspace builds a minimal COOWorkspace object for test responses.
+func unstructuredWorkspace(name, phase, podName string) map[string]interface{} {
+	obj := map[string]interface{}{
+		"apiVersion": "coo.itsacoo.com/v1alpha1",
+		"kind":       "COOWorkspace",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": defaultNamespace,
+		},
+		"spec": map[string]interface{}{
+			"mode":  "freestyle",
+			"repo":  "owner/repo",
+			"model": "claude-sonnet-4-5",
+			"ttl":   "4h",
+		},
+	}
+	if phase != "" || podName != "" {
+		status := map[string]interface{}{}
+		if phase != "" {
+			status["phase"] = phase
+		}
+		if podName != "" {
+			status["podName"] = podName
+		}
+		obj["status"] = status
+	}
+	return obj
+}
+
+// TestBuildCOOWorkspace verifies the CR spec is assembled correctly.
+func TestBuildCOOWorkspace(t *testing.T) {
+	opts := CreateOptions{
+		Repo:  "owner/repo",
+		Model: "claude-sonnet-4-5",
+		TTL:   "4h",
+	}
+	ws := buildCOOWorkspace("ws-test", defaultNamespace, "freestyle", opts, defaultWorkerImage)
+
+	if ws.GetName() != "ws-test" {
+		t.Errorf("name = %q, want ws-test", ws.GetName())
+	}
+	if ws.GetNamespace() != defaultNamespace {
+		t.Errorf("namespace = %q, want %s", ws.GetNamespace(), defaultNamespace)
+	}
+
+	mode, _, _ := unstructured.NestedString(ws.Object, "spec", "mode")
+	if mode != "freestyle" {
+		t.Errorf("spec.mode = %q, want freestyle", mode)
+	}
+
+	repo, _, _ := unstructured.NestedString(ws.Object, "spec", "repo")
+	if repo != "owner/repo" {
+		t.Errorf("spec.repo = %q, want owner/repo", repo)
+	}
+
+	image, _, _ := unstructured.NestedString(ws.Object, "spec", "image")
+	if image != defaultWorkerImage {
+		t.Errorf("spec.image = %q, want %s", image, defaultWorkerImage)
+	}
+
+	policy, _, _ := unstructured.NestedString(ws.Object, "spec", "imagePullPolicy")
+	if policy != "IfNotPresent" {
+		t.Errorf("spec.imagePullPolicy = %q, want IfNotPresent", policy)
+	}
+}
+
+// TestBuildCOOWorkspace_Handoff verifies handoff mode sets conceptRef.
+func TestBuildCOOWorkspace_Handoff(t *testing.T) {
+	opts := CreateOptions{Concept: "my-concept"}
+	ws := buildCOOWorkspace("ws-test", defaultNamespace, "handoff", opts, defaultWorkerImage)
+
+	mode, _, _ := unstructured.NestedString(ws.Object, "spec", "mode")
+	if mode != "handoff" {
+		t.Errorf("spec.mode = %q, want handoff", mode)
+	}
+
+	ref, _, _ := unstructured.NestedString(ws.Object, "spec", "conceptRef")
+	if ref != "my-concept" {
+		t.Errorf("spec.conceptRef = %q, want my-concept", ref)
+	}
+}
+
+// TestBuildCOOWorkspace_Defaults verifies empty model/ttl get default values.
+func TestBuildCOOWorkspace_Defaults(t *testing.T) {
+	opts := CreateOptions{Repo: "owner/repo"} // no model or TTL
+	ws := buildCOOWorkspace("ws-test", defaultNamespace, "freestyle", opts, defaultWorkerImage)
+
+	model, _, _ := unstructured.NestedString(ws.Object, "spec", "model")
+	if model != "claude-sonnet-4-5" {
+		t.Errorf("spec.model = %q, want claude-sonnet-4-5", model)
+	}
+
+	ttl, _, _ := unstructured.NestedString(ws.Object, "spec", "ttl")
+	if ttl != "4h" {
+		t.Errorf("spec.ttl = %q, want 4h", ttl)
+	}
+}
+
+// TestWaitForReady_ImmediateReady verifies that waitForReady returns immediately
+// when the workspace is already in Ready phase on the first poll.
+func TestWaitForReady_ImmediateReady(t *testing.T) {
+	wsObj := unstructuredWorkspace("ws-test", "Ready", "pod-abc123")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "ws-test") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(mustMarshal(t, wsObj))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	rt := newTestK8sRuntime(t, srv.URL)
+	// Use a very short poll interval for the test.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	podName, err := rt.waitForReadyWithInterval(ctx, "ws-test", 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("waitForReady returned unexpected error: %v", err)
+	}
+	if podName != "pod-abc123" {
+		t.Errorf("podName = %q, want pod-abc123", podName)
+	}
+}
+
+// TestWaitForReady_EventuallyReady verifies the poll loop keeps going until Ready.
+func TestWaitForReady_EventuallyReady(t *testing.T) {
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "ws-test") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			count := atomic.AddInt32(&callCount, 1)
+			phase := "Pending"
+			podName := ""
+			if count >= 3 {
+				phase = "Ready"
+				podName = "pod-xyz"
+			}
+			_, _ = w.Write(mustMarshal(t, unstructuredWorkspace("ws-test", phase, podName)))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	rt := newTestK8sRuntime(t, srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	podName, err := rt.waitForReadyWithInterval(ctx, "ws-test", 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("waitForReady returned unexpected error: %v", err)
+	}
+	if podName != "pod-xyz" {
+		t.Errorf("podName = %q, want pod-xyz", podName)
+	}
+	if atomic.LoadInt32(&callCount) < 3 {
+		t.Errorf("expected at least 3 polls, got %d", callCount)
+	}
+}
+
+// TestWaitForReady_ContextCancelled verifies cancellation is respected.
+func TestWaitForReady_ContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always return Pending.
+		if strings.Contains(r.URL.Path, "ws-test") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(mustMarshal(t, unstructuredWorkspace("ws-test", "Pending", "")))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	rt := newTestK8sRuntime(t, srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel immediately.
+	cancel()
+
+	_, err := rt.waitForReadyWithInterval(ctx, "ws-test", 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error when context is cancelled")
+	}
+}
+
+// TestWaitForReady_FailedPhase verifies that a Failed phase returns an error.
+func TestWaitForReady_FailedPhase(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "ws-test") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(mustMarshal(t, unstructuredWorkspace("ws-test", "Failed", "")))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	rt := newTestK8sRuntime(t, srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := rt.waitForReadyWithInterval(ctx, "ws-test", 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error for Failed phase")
+	}
+	if !strings.Contains(err.Error(), "Failed") {
+		t.Errorf("error should mention 'Failed', got: %v", err)
+	}
+}
+
+// TestCreateWorkspace_MissingRepoAndConcept verifies validation.
+func TestCreateWorkspace_MissingRepoAndConcept(t *testing.T) {
+	rt := &K8sRuntime{namespace: defaultNamespace}
+	err := rt.CreateWorkspace(context.Background(), CreateOptions{})
+	if err == nil {
+		t.Fatal("expected error when neither --repo nor --concept is provided")
+	}
+	if !strings.Contains(err.Error(), "--repo") {
+		t.Errorf("error should mention --repo, got: %v", err)
+	}
+}
+
+// TestListActiveWorkspaces verifies filtering out Terminated workspaces.
+func TestListActiveWorkspaces(t *testing.T) {
+	items := []map[string]interface{}{
+		unstructuredWorkspace("ws-running", "Ready", "pod-1"),
+		unstructuredWorkspace("ws-pending", "Pending", ""),
+		unstructuredWorkspace("ws-done", "Terminated", ""),
+		unstructuredWorkspace("ws-uninit", "", ""), // phase not set yet
+	}
+	listResp := map[string]interface{}{
+		"apiVersion": "coo.itsacoo.com/v1alpha1",
+		"kind":       "COOWorkspaceList",
+		"metadata":   map[string]interface{}{"resourceVersion": ""},
+		"items":      items,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "cooworkspaces") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(mustMarshal(t, listResp))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	rt := newTestK8sRuntime(t, srv.URL)
+	active, err := rt.listActiveWorkspaces(context.Background())
+	if err != nil {
+		t.Fatalf("listActiveWorkspaces returned unexpected error: %v", err)
+	}
+
+	// Terminated and uninitialised workspaces should be excluded.
+	if len(active) != 2 {
+		t.Errorf("got %d active workspaces, want 2", len(active))
+	}
+	for _, ws := range active {
+		name := ws.GetName()
+		if name == "ws-done" || name == "ws-uninit" {
+			t.Errorf("unexpected workspace in active list: %s", name)
+		}
+	}
+}


### PR DESCRIPTION
## Implementation Complete

## Summary

- Implements `K8sRuntime.CreateWorkspace` for k8s mode: validates options, lists non-terminated workspaces (prompts to resume), generates `ws-<timestamp>` name, builds and creates a `COOWorkspace` CR via the dynamic client, polls for `status.phase == Ready` (120 s timeout with progress dots), then exec-s into the pod via `kubectl exec -it`
- Adds `dynamicClient dynamic.Interface`, `restConfig *rest.Config`, and `namespace string` fields to `K8sRuntime`; wires them up in `newK8sRuntime`
- Extracts `buildRuntimeClients` (no short probe timeout) alongside the existing `buildDiscoveryClient` (5 s probe timeout)
- Adds `waitForReadyWithInterval` variant for testability with a configurable poll interval
- Tests cover: CR spec assembly (freestyle + handoff + defaults), readiness polling (immediate ready, eventually ready, context cancelled, failed phase), input validation, and active-workspace list filtering

Closes #5

## Tasks Completed

- [x] Analyze the issue requirements
- [x] Implement the core changes
- [x] Add tests for new functionality
- [x] Update documentation if needed


---
**Issue:** #5 (Closes #5)
**Agent:** `backend-engineer`
**Branch:** `feature/5-coo-cli-workspace-sprint-2-issue-5`